### PR TITLE
Handle requirements syntax more simply and parse Poetry dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.0.1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,16 +10,16 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.3.0
+    rev: v2.5.0
     hooks:
     -   id: reorder-python-imports
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.0
+    rev: 3.9.2
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 21.6b0
     hooks:
     -   id: black

--- a/dep_license/__main__.py
+++ b/dep_license/__main__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from dep_license import run
 
 
@@ -6,4 +8,5 @@ def main():
 
 
 if __name__ == "__main__":
+    warnings.simplefilter("ignore", UserWarning)
     exit(main())

--- a/dep_license/utils.py
+++ b/dep_license/utils.py
@@ -9,7 +9,7 @@ import pkg_resources
 import toml
 import yaml
 
-logger = logging.getLogger("__name__")
+logger = logging.getLogger("dep_license")
 
 
 def parse_file(input_file, base_name, dev=False):

--- a/release.sh
+++ b/release.sh
@@ -3,7 +3,7 @@ set -ex
 git pull origin master
 # bump version
 docker run --rm -v "$PWD":/app treeder/bump --filename dep_license/VERSION $1
-version=`cat dep_license/VERSION`
+version=$(cat dep_license/VERSION)
 echo "version: $version"
 
 # tag it


### PR DESCRIPTION
Fantastic tool. I wanted to use it for my project but ran into problems.
Basically, I needed to include [Poetry](https://python-poetry.org/) dependencies and allow hashes listed in requirements.txt files.

Here are the changes:
- Hashes, which are permitted in requirements.txt, now work
- Use a simple regex instead of parse_requirements (handles more cases, like hashes)
- Parse runtime Poetry dependencies (`tool.poetry.dependencies`)
- Bumped pre-commit versions & ran black
- Fixed a few (very) minor bugs
- Used pathlib because it's much simpler and python 3.6 is required anyway

Sorry about the mixed changes (pathlib, f-expressions, etc) -- I just made those edits while reading the code.

(This is a draft edit -- I didn't add tests yet.)