### PR TITLE
Added support for packages with multiple licenses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+Pipfile.lock
+
 # Created by .ignore support plugin (hsz.mobi)
 ### Python template
 # Byte-compiled / optimized / DLL files

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+#!/usr/bin/env make
+#
+# Makefile
+#
+
+PACKAGE_NAME=dep_license
+
+install:
+	pip3 install . --user
+
+uninstall:
+	pip3 uninstall --yes $(PACKAGE_NAME)
+
+install-dev:
+	pipenv install --dev
+	pipenv run pre-commit install
+
+uninstall-dev:
+	pipenv --rm
+
+test:
+	pipenv run python -m unittest $(PACKAGE_NAME).tests.tests --failfast --locals --verbose
+
+dist:
+	pipenv run python setup.py sdist
+	pipenv run python setup.py bdist_wheel
+	pipenv run twine check dist/*
+
+upload:
+	pipenv run twine upload dist/*

--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,6 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-# Documentation.
-Sphinx = "~=4.0"
-sphinx-rtd-theme = "~=0.5"
-
 # Tools.
 pre-commit = "~=2.13"
 pytest = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,22 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+# Documentation.
+Sphinx = "~=4.0"
+sphinx-rtd-theme = "~=0.5"
+
+# Tools.
+pre-commit = "~=2.13"
+pytest = "*"
+
+[packages]
+tabulate = "*"
+GitPython = "*"
+toml = "*"
+PyYAML = "*"
+
+[requires]
+python_version = "*"

--- a/dep_license/__init__.py
+++ b/dep_license/__init__.py
@@ -127,11 +127,13 @@ def worker(d):
     meta = output.get("license", "")
     record.append(meta.strip())
 
-    license_class = ""
+    license_class = list()
     classifier = output.get("classifiers", "")
+
+    # Group all license classifiers.
     for c in classifier:
         if c.startswith("License"):
-            license_class = "::".join([x.strip() for x in c.split("::")[1:]])
+            license_class.append("::".join([x.strip() for x in c.split("::")[1:]]))
     record.append(license_class)
 
     return dict(zip(COLUMNS, record))

--- a/dep_license/__init__.py
+++ b/dep_license/__init__.py
@@ -64,7 +64,11 @@ def get_params(argv=None):
     )
     parser.add_argument("PROJECT", nargs="+", help="path to project or its GIT repo")
     parser.add_argument(
-        "-w", "--workers", default=5, help="number of workers to run in parallel"
+        "-w",
+        "--workers",
+        default=5,
+        type=int,
+        help="number of workers to run in parallel",
     )
     parser.add_argument(
         "-f", "--format", default="github", help="define how result is formatted"


### PR DESCRIPTION
Packages with multiple licenses such as [docutils](https://pypi.org/project/docutils/) only had the last license classifier recorded.
This PR adds them all using a list. This is just a quick fix so I have not updated the tests.

I added an `int` type in an argparse argument because without it an exception was raised.