### PR TITLE
Adding more columns to the display #4

### DIFF
--- a/dep_license/__init__.py
+++ b/dep_license/__init__.py
@@ -69,7 +69,7 @@ def get_params(argv=None):
         "-f", "--format", default="github", help="define how result is formatted"
     )
     parser.add_argument(
-        "--columns", nargs='+', default=["Name", "License", "License Classifier"], help="define which columns to display. The options are ['Author', 'Author Email', 'Bugtrack Url', 'Classifiers', 'Description', 'Description Content Type', 'Docs Url', 'Download Url', 'Downloads', 'Home Page', 'Keywords', 'License', 'Maintainer', 'Maintainer Email', 'Name', 'Package Url', 'Platform', 'Project Url', 'Project Urls', 'Release Url', 'Requires Dist', 'Requires Python', 'Summary', 'Version', 'Yanked', 'Yanked Reason']. Defaults to only the license information"
+        "--columns", nargs='+', default=["Name", "Meta", "Classifier"], help="define which columns to display. The options are ['Author', 'Author Email', 'Bugtrack Url', 'Classifiers', 'Description', 'Description Content Type', 'Docs Url', 'Download Url', 'Downloads', 'Home Page', 'Keywords', 'License', 'Maintainer', 'Maintainer Email', 'Name', 'Package Url', 'Platform', 'Project Url', 'Project Urls', 'Release Url', 'Requires Dist', 'Requires Python', 'Summary', 'Version', 'Yanked', 'Yanked Reason']. Defaults to only the license information"
     )
     parser.add_argument("-o", "--output", default=None, help="path for output file")
     parser.add_argument(
@@ -131,7 +131,9 @@ def worker(d):
         if c.startswith("License"):
             license_class.add("::".join([x.strip() for x in c.split("::")[1:]]))
 
-    record['License Classifier'] = ', '.join(license_class)
+    record['Classifier'] = ', '.join(license_class)
+    record['Meta'] = record['License']
+    record['Name'] = d
 
     return record
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,30 +4,34 @@ from dep_license import start_concurrent
 from dep_license import worker
 
 
-@pytest.mark.parametrize(
-    "dependency,expected",
-    [
-        (
-            "dep_license",
-            {
-                "Name": "dep_license",
-                "Meta": "MIT",
-                "Classifier": "OSI Approved::MIT License",
-            },
-        ),
-        ("SomethingThatDoesntExist", None),
-    ],
-)
+@pytest.fixture
+def dependency():
+    return 'dep_license'
+
+
+@pytest.fixture
+def dependency_does_not_exist():
+    return 'SomethingThatDoesntExist'
+
+
+@pytest.fixture
+def expected(dependency):
+    return {
+        "Name": dependency,
+        "Meta": "MIT",
+        "Classifier": "OSI Approved::MIT License",
+    }.items()
+
+
 def test_worker(dependency, expected):
-    assert worker(dependency) == expected
+    assert worker(dependency).items() >= expected
 
 
-def test_concurrent_workers():
-    results = start_concurrent(["dep_license", "SomethingElseThatDoesntExist"])
-    assert results == [
-        {
-            "Name": "dep_license",
-            "Meta": "MIT",
-            "Classifier": "OSI Approved::MIT License",
-        }
-    ]
+def test_worker_dependency_does_not_exist(dependency_does_not_exist):
+    assert worker(dependency_does_not_exist) is None
+
+
+def test_concurrent_workers(dependency, dependency_does_not_exist, expected):
+    results = start_concurrent([dependency, dependency_does_not_exist])
+    assert len(results), 1
+    assert results[0].items() >= expected


### PR DESCRIPTION
I've added a new command line argument called `columns` which allows the user to retrieve more than just license information. An example call
> deplic /home/user/myproject --format json --columns Name Version Meta "Project Url"

which would output:
```
[
    {
        "Name": "pdf2image",
        "Version": "1.16.0",
        "Meta": "MIT",
        "Project Url": "https://pypi.org/project/pdf2image/"
    },
    {
        "Name": "blowfish",
        "Version": "0.6.1",
        "Meta": "GPLv3",
        "Project Url": "https://pypi.org/project/blowfish/"
    }
]
```

I've checked and it works in json/csv/tabulated formats. Also by default, the output is still the same - only license information shows